### PR TITLE
Add support for template strings to JavaScript mode (Fixes #33). A fe…

### DIFF
--- a/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/SyntaxDefinition.xml
+++ b/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/SyntaxDefinition.xml
@@ -91,7 +91,7 @@
             </keywords>
 
             <keywords id="Operators" useforautocomplete="no" scope="language.operator">
-							<regex>([\+\-\*\/\=\!\&lt;\&gt;\%])</regex>
+                <regex>([\+\-\*\/\=\!\&lt;\&gt;\%])</regex>
             </keywords>
 
             <keywords id="Numbers" useforautocomplete="no" scope="language.constant.numeric.js">
@@ -141,6 +141,16 @@
             <state id="SingleString" type="string" scope="string.single.js">
                 <begin><regex>'</regex></begin>
                 <end><regex>(?&lt;!\\)(\\\\)*'</regex></end>
+            </state>
+
+            <state id="TemplateString" type="string" scope="string.template.js">
+                <begin><regex>`</regex></begin>
+                <end><regex>(?&lt;!\\)(\\\\)*`</regex></end>
+                <state id="TemplateExpression" type="block" scope="meta.block.curly">
+                    <begin><regex>\${</regex><autoend>}</autoend></begin>
+                    <end><regex>}</regex></end>
+                    <import/>
+                </state>
             </state>
 
             <state id="Block" type="block" foldable="yes" indent="yes" scope="meta.block.curly">


### PR DESCRIPTION
…w notes:

1. Wasn't sure whether to name the state TemplateLiteral (the actual term), but stuck with TemplateString to match SingleString and DoubleString.
2. This supports template expressions using nested states.

Reviewed by @tolmasky.