### PR TITLE
Issues/issue 38 markdown javascript codefence

### DIFF
--- a/SubEthaEdit-Mac/Modes/Markdown.seemode/Contents/Resources/SyntaxDefinition.xml
+++ b/SubEthaEdit-Mac/Modes/Markdown.seemode/Contents/Resources/SyntaxDefinition.xml
@@ -86,6 +86,12 @@
 				<regex>(`[^`\r\n]+?`)</regex>
            	</keywords>
 
+            <state id="CodeBlock-JavaScript" usesymbolsfrommode="Javascript" useautocompletefrommode="Javascript" foldable="yes" scope="meta.block.js">
+                <begin><regex>^```(?:javascript|js|jsx|node)</regex></begin>
+                <end><regex>```</regex></end>
+                <import mode = "Javascript" />
+            </state>
+
             <state id="CodeBlock" type="string" foldable="yes" scope="structured.raw.code">
                 <begin><regex>^```</regex><autoend>```</autoend></begin>
                 <end><regex>```</regex></end>

--- a/SubEthaEdit-Mac/Source/AppController.m
+++ b/SubEthaEdit-Mac/Source/AppController.m
@@ -429,11 +429,6 @@ static AppController *sharedInstance = nil;
         // Observe the app's effective appearance
         [NSApp addObserver:self forKeyPath:@"effectiveAppearance" options:0 context:nil];
     }
-
-    if (@available(macOS 10.12, *)) {
-        // Disable tabbing as we use PSMTabBar
-        [NSWindow setAllowsAutomaticWindowTabbing:NO];
-    }
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {

--- a/SubEthaEdit-Mac/Source/DNDArrayController.m
+++ b/SubEthaEdit-Mac/Source/DNDArrayController.m
@@ -79,7 +79,7 @@ NSString *MovedRowsType = @"MOVED_ROWS_TYPE";
         
         // set selected rows to those that were just moved
         // Need to work out what moved where to determine proper selection...
-        int rowsAbove = [self rowsAboveRow:row inIndexSet:indexSet];
+        NSInteger rowsAbove = [self rowsAboveRow:row inIndexSet:indexSet];
         
         NSRange range = NSMakeRange(row - rowsAbove, [indexSet count]);
         indexSet = [NSIndexSet indexSetWithIndexesInRange:range];

--- a/SubEthaEdit-Mac/Source/Debug/DebugController.m
+++ b/SubEthaEdit-Mac/Source/Debug/DebugController.m
@@ -76,7 +76,7 @@ static DebugController * sharedInstance = nil;
 
 - (void)enableDebugMenu:(BOOL)flag
 {
-    int indexOfDebugMenu = [[NSApp mainMenu] indexOfItemWithTitle:@"Debug"];
+    NSInteger indexOfDebugMenu = [[NSApp mainMenu] indexOfItemWithTitle:@"Debug"];
     
     if (flag && indexOfDebugMenu == -1) {
         NSMenuItem *debugItem = [[NSMenuItem alloc] initWithTitle:@"Debug" action:nil keyEquivalent:@""];

--- a/SubEthaEdit-Mac/Source/SyntaxHighlighter.m
+++ b/SubEthaEdit-Mac/Source/SyntaxHighlighter.m
@@ -510,7 +510,7 @@ static unsigned int trimmedStartOnLevel = UINT_MAX;
     // Check if the string after the area we just colored matches up
     // Make it dirty if there is a logical glitch
     
-    int nextIndex = NSMaxRange(aRange);
+    NSUInteger nextIndex = NSMaxRange(aRange);
     if (nextIndex >= [theString length]) return;
     
     if (([aString attribute:kSyntaxHighlightingIsCorrectAttributeName atIndex:nextIndex effectiveRange:nil])) {
@@ -518,9 +518,9 @@ static unsigned int trimmedStartOnLevel = UINT_MAX;
         BOOL leftIsEnd = [[aString attribute:kSyntaxHighlightingStateDelimiterName atIndex:nextIndex-1 effectiveRange:nil] isEqualTo:kSyntaxHighlightingStateDelimiterEndValue];
         BOOL rightIsStart = [[aString attribute:kSyntaxHighlightingStateDelimiterName atIndex:nextIndex effectiveRange:nil] isEqualTo:kSyntaxHighlightingStateDelimiterStartValue];
         NSArray *leftStack = [aString attribute:kSyntaxHighlightingStackName atIndex:nextIndex-1 effectiveRange:nil];
-        int leftCount = [leftStack count];
+        NSUInteger leftCount = [leftStack count];
         NSArray *rightStack = [aString attribute:kSyntaxHighlightingStackName atIndex:nextIndex effectiveRange:nil];
-        int rightCount = [rightStack count];
+        NSUInteger rightCount = [rightStack count];
         
         // Same stack, no ends and begins or both an end and a begin
         if ([leftStack isEqualToArray:rightStack]) {


### PR DESCRIPTION
Support Javascript syntax highlighting in Markdown code-fences. Partial fix for #38. Eventually it would be nice to have a more automatic way of assembling these, but for now I'll just attack them one at a time.

Reviewed by @tolmasky.