### PR TITLE
Fixes #7. This adds support for the async keyword (only when next to …

### DIFF
--- a/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/ChangeLog.txt
+++ b/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/ChangeLog.txt
@@ -1,3 +1,8 @@
+Changes with Version 5.0.1 (SEE 5.0.1)
+    *) SYNTAX: added new built-in objects URL and URLSearchParams
+    *) SYNTAX: updated to support async and generator functions
+    *) SYNTAX: updated to support new ES 2017 and 2018 keywords
+
 Changes with Version 4.0 (SEE 4.0)
 	*) SYNTAX: updated for syntax scopes
 	*) SYNTAX: markup cleanup

--- a/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/RegexSymbols.xml
+++ b/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/RegexSymbols.xml
@@ -12,7 +12,7 @@
     </symbol>
 
     <symbol id="Funtions" symbol="f()_#6AB18D" indentation="0" ignoreblocks="yes">
-        <regex>(?&lt;=[\n\r]|^)\s{0,512}function\s{1,512}([^{]{0,512})(?=\s{0,512}\{)</regex>
+        <regex>(?&lt;=[\n\r]|^)\s{0,512}(?:async\s{1,512})?function\s{1,512}\*?\s{0,512}([^{]{0,512})(?=\s{0,512}\{)</regex>
         <postprocess>
             <find>\([^\)]*\)</find>
             <replace>()</replace>
@@ -24,7 +24,7 @@
     </symbol>
 
     <symbol id="Inline Funtions" symbol="f()_#6AB18D" indentation="0" ignoreblocks="yes">
-        <regex>(\w{1,512})\s{0,512}=\s{0,512}function\s{0,512}\([^\)]{0,512}\)(?=\s{0,512}\{)</regex>
+        <regex>(\w{1,512})\s{0,512}=\s{0,512}(?:async\s{1,512})?function\s{0,512}\*?\s{0,512}\([^\)]{0,512}\)(?=\s{0,512}\{)</regex>
         <postprocess>
             <find>(.*)</find>
             <replace>\1()</replace>

--- a/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/SyntaxDefinition.xml
+++ b/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/SyntaxDefinition.xml
@@ -34,7 +34,7 @@
             </keywords>
 
             <keywords id="Keywords" useforautocomplete="yes" scope="keyword.control.js">
-                <string>async function</string>
+                <regex>(async)\s{1,512}function</regex>
                 <string>await</string>
                 <string>break</string>
                 <string>case</string>

--- a/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/SyntaxDefinition.xml
+++ b/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/SyntaxDefinition.xml
@@ -29,9 +29,12 @@
                 <string>SyntaxError</string>
                 <string>TypeError</string>
                 <string>URIError</string>
+                <string>URL</string>
+                <string>URLSearchParams</string>
             </keywords>
 
             <keywords id="Keywords" useforautocomplete="yes" scope="keyword.control.js">
+                <string>async function</string>
                 <string>await</string>
                 <string>break</string>
                 <string>case</string>


### PR DESCRIPTION
…function), as well as allowing async functions and generators show up in the pop-up menu. I've also gone ahead and added new built-in objects and updated the Changelog.

Reviewed by @tolmasky.