### PR TITLE
Auto-generate language-specific code blocks for the Markdown mode in a build phase.

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -6,6 +6,8 @@
 
 * Dominik [@monkeydom](https://mastodon.technology/@monkeydom) Wagner - [GitHub](https://github.com/monkeydom) [Mastodon](https://mastodon.technology/@monkeydom) [Twitter](https://twitter.com/monkeydom) [Blog](https://coding.monkeydom.de/)
 
+* Francisco Ryan Tolmasky I - [GitHub](https://github.com/tolmasky) [Twitter](https://twitter.com/tolmasky) [Blog](https://tolmasky.com/)
+
 ## Contributors
 
 ### Engineering

--- a/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/ModeSettings.xml
+++ b/SubEthaEdit-Mac/Modes/Javascript.seemode/Contents/Resources/ModeSettings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <recognition>
-        <extension>js</extension>
+        <extension>mjs</extension>
         <extension>javascript</extension>
+        <extension>js</extension>
         <extension>jscript</extension>
         <extension>jsx</extension>
     </recognition>

--- a/SubEthaEdit-Mac/Modes/Markdown.seemode/Contents/Resources/SyntaxDefinition.xml
+++ b/SubEthaEdit-Mac/Modes/Markdown.seemode/Contents/Resources/SyntaxDefinition.xml
@@ -86,11 +86,7 @@
 				<regex>(`[^`\r\n]+?`)</regex>
            	</keywords>
 
-            <state id="CodeBlock-JavaScript" usesymbolsfrommode="Javascript" useautocompletefrommode="Javascript" foldable="yes" scope="meta.block.js">
-                <begin><regex>^```(?:javascript|js|jsx|node)</regex></begin>
-                <end><regex>```</regex></end>
-                <import mode = "Javascript" />
-            </state>
+            <code-blocks/>
 
             <state id="CodeBlock" type="string" foldable="yes" scope="structured.raw.code">
                 <begin><regex>^```</regex><autoend>```</autoend></begin>

--- a/SubEthaEdit-Mac/Modes/Ruby.seemode/Contents/Resources/ModeSettings.xml
+++ b/SubEthaEdit-Mac/Modes/Ruby.seemode/Contents/Resources/ModeSettings.xml
@@ -1,14 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <recognition>
+        <extension>arb</extension>
+        <extension>gemspec</extension>
+        <extension>podspec</extension>
+        <extension>prawn</extension>
+        <extension>rake</extension>
         <extension>rb</extension>
         <extension>rbw</extension>
+        <extension>ru</extension>
         <extension>ruby</extension>
         <extension>rbx</extension>
         <extension>rxml</extension>
         <extension>builder</extension>
         <extension>rjs</extension>
-        <filename>Rakefile</filename>
+
+        <filename casesensitive="yes">Berksfile</filename>
+        <filename casesensitive="yes">Capfile</filename>
+        <filename casesensitive="yes">Dangerfile</filename>
+        <filename casesensitive="yes">Guardfile</filename>
+        <filename casesensitive="yes">Gemfile</filename>
+        <filename casesensitive="yes">Podfile</filename>
+        <filename casesensitive="yes">Rakefile</filename>
+        <filename casesensitive="yes">Vagrantfile</filename>
+
         <regex>\A#!/usr/bin/(env )?ruby</regex>
     </recognition>
 </settings>

--- a/SubEthaEdit-Mac/SubEthaEdit.xcodeproj/project.pbxproj
+++ b/SubEthaEdit-Mac/SubEthaEdit.xcodeproj/project.pbxproj
@@ -2620,6 +2620,7 @@
 			buildConfigurationList = C05733C708A9546B00998B17 /* Build configuration list for PBXNativeTarget "SubEthaEdit" */;
 			buildPhases = (
 				8D15AC2B0486D014006FF6A4 /* Resources */,
+				9E016A592259867A00142CCA /* ShellScript */,
 				8D15AC300486D014006FF6A4 /* Sources */,
 				8D15AC330486D014006FF6A4 /* Frameworks */,
 				149EC6970958726E002BDC41 /* Copy Files (Frameworks) */,
@@ -3060,6 +3061,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+		};
+		9E016A592259867A00142CCA /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/generate-markdown-mode-code-blocks.rb",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\ncd $TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Modes\nruby $PROJECT_DIR/generate-markdown-mode-code-blocks.rb $PROJECT_DIR/Modes/Markdown.seemode $TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Modes/Markdown.seemode\n";
 		};
 		F213791B2191BBEE00C74681 /* Mac App Store Modifications */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/SubEthaEdit-Mac/generate-markdown-mode-code-blocks.rb
+++ b/SubEthaEdit-Mac/generate-markdown-mode-code-blocks.rb
@@ -1,0 +1,155 @@
+require "rexml/document"
+
+# We have to support both ``` and ~~~.
+class Block
+    attr_reader :name, :fence
+
+    def initialize(name, fence)
+        @name = name
+        @fence = fence
+    end
+
+    Wave = Block.new("Wave", "~~~")
+    Ticks = Block.new("Ticks", "```")
+
+    def self.toStates(path)
+
+        language = File.basename(path, File.extname(path))
+        settings = XML.from("#{path}/Contents/Resources/ModeSettings.xml")
+
+        # For each extension, we want to match both the bare extension (extname)
+        # as well as a filename with that exenstion (filename.extname). As such,
+        # we optionally match any non-newline character string ending in a
+        # period, followed by the extension.
+        extensions = toRegExpUnion(settings, "settings/recognition/extension")
+        withExtensions = extensions.empty? ? "" : "(?:[^\\.\\r\\n]*\\.)?(?:#{extensions})"
+
+        # Exact filenames are easy, just looks for them specifically.
+        filenames = toRegExpUnion(settings, "settings/recognition/filename")
+
+        # Union both together.
+        groups = [withExtensions, filenames]
+            .select { |group| group != "" }
+            .map { |group| "(?:#{group})" }
+            .join("|")
+
+        # Return both the Wave and Ticks states.
+        [Wave, Ticks].map do |block|
+            block.toState(language, groups)
+        end
+
+    end
+
+    # Generate the <state> tag for a given language and match criteria.
+    def toState(language, match)
+
+        # This is a bit complex in order to get the proper highlighting we want.
+        # We have an outer state  that matches the code fence up to, but not
+        # including, the newline. This makes it so that this begin section is
+        # not highlighted. Then, internally, we'll match just the newline.
+        beginRegExp = "^#{@fence}(?:#{match})(?:[^\\S\\r\\n][^\\n]*)?(?=\\n)"
+        endRegExp = "^#{@fence}"
+
+        Node.state ({
+            "id" => "CodeBlock#{@name}-#{language}",
+            "foldable" => "yes",
+            "scope" => "meta.codeblock.markdown",
+            :children =>
+            [
+                Node.begin(Node.regex(beginRegExp)),
+                Node.end(Node.regex(endRegExp)),
+                Node.state({
+                    "id" => "CodeBlock#{@name}-#{language}-Code",
+                    "usesymbolsfrommode" => language,
+                    "useautocompletefrommode" => language,
+                    "scope" => "meta.codeblock.#{language}",
+                    :children =>
+                    [
+                        Node.begin(Node.regex("\\n")),
+                        Node.end(Node.regex("\\n(?=#{@fence})")),
+                        Node.import("mode" => language)
+                    ]
+                })
+            ]
+        })
+
+    end
+end
+
+def toRegExpUnion(xml, match)
+    REXML::XPath
+        .match(xml, match)
+        .map { |element|
+            element.attribute("casesensitive").to_s == "yes" ?
+                element.text : "(?i:#{element.text})" }
+        .join("|")
+end
+
+class XML
+    def self.from (path)
+        file = File.new(path)
+        xml = REXML::Document.new(file)
+    end
+end
+
+class Node
+
+    def self.method_missing(name, items)
+        element = REXML::Element.new(name.to_s)
+        if (items.is_a? String)
+            element.add_text(items)
+        elsif (items.instance_of? REXML::Element)
+            element.add_element(items)
+        else
+            items.each do |key, value|
+                if key.is_a? String
+                    element.add_attribute(key, value)
+                elsif (key == :child)
+                    element.add_element(child)
+                elsif (key == :children)
+                    value.each do |child|
+                        if child.is_a? String
+                            element.add_text(child)
+                        else
+                            element.add_element(child)
+                        end
+                    end
+                end
+            end
+        end
+        element
+    end
+end
+
+
+inputPath = "#{ARGV[0]}/Contents/Resources/SyntaxDefinition.xml"
+outputPath = "#{ARGV[1]}/Contents/Resources/SyntaxDefinition.xml"
+
+markdownSyntax = XML.from(inputPath)
+parent = markdownSyntax.root.elements["/syntax/states/default"]
+
+excluded = Set[
+    # For some reason, including erlang causes SubEthaEdit to crash, some weird
+    # recursive state or something?
+    "erlang.seemode",
+
+    # For now, don't have rescursive Markdown highlighting, might want to do
+    # something clever later though. Currently it's not clear how to end the
+    # match since code fences technically match within the nested Markdown.
+    "Markdown.seemode"
+]
+
+Dir.glob("*.seemode")
+    .select { |path| !excluded.include?(path) }
+    .each do |path|
+        Block::toStates(path).each do |state|
+            parent.insert_before("code-blocks", state)
+        end
+    end
+parent.delete_element("code-blocks")
+
+File.open(outputPath, "w") do |file|
+    formatter = REXML::Formatters::Default.new(4)
+    formatter.write(markdownSyntax, file)
+end
+


### PR DESCRIPTION
This is a partial fix for #38. In this commit, I auto-generate the code-block states for all the different modes in the Modes folder with a new [run script build phase](https://github.com/subethaedit/SubEthaEdit/commit/bdc079049aae126312c9698f5b07f75c072b65df#diff-ca4cddfb0198a04a9f62e41227063792R3065). The actual generation is done in the [generate-markdown-mode-code-blocks.rb](https://github.com/subethaedit/SubEthaEdit/compare/develop...tolmasky:automatic-code-block#diff-3e65c5910704178b89c0d07a60323543) file. 

### Details
1. I chose to write this in Ruby since it is built-in to macOS and thus requires no extra dependencies to be added for building.
2. As part of this fix, I've also updated the JavaScript and Ruby ModeSettings.xml to have all the latest extensions and filenames.
3. The script reads from the source directory's Markdown mode and writes to the build directory's Markdown mode, and has generate-markdown-mode-code-blocks.rb listed as an input file, so that the build phase will be rerun if that file changes. See possible improvements below.
4. The state logic ended up being fairly complex, because I wanted to fix the fact that the internal imported mode currently applies to the text matched in the `begin` and `end` tags. So for example, you would get something like this:

    <img width="209" alt="Screen Shot 2019-04-07 at 10 30 06 AM" src="https://user-images.githubusercontent.com/23753/55687284-253b9c80-5920-11e9-8d9f-6f7679a145cf.png">

    However, with the nested state system used here, we now correctly get this:

    <img width="199" alt="Screen Shot 2019-04-07 at 10 31 42 AM" src="https://user-images.githubusercontent.com/23753/55687309-5caa4900-5920-11e9-92aa-3c719e47b7ae.png">

    This is important because metadata can be placed on the rest of the line in a code fence. This is actually a problem in all mode states I think. For example, observe this script tag in HTML:

    <img width="304" alt="Screen Shot 2019-04-07 at 10 40 18 AM" src="https://user-images.githubusercontent.com/23753/55687414-99c30b00-5921-11e9-8eec-a71976291630.png">

    The var attribute is incorrectly highlighted as a JavaScript keyword.

5. Additionally, the code fences now match filenames as well as language names. Specifically, the algorithm is:

    1. Match code fence delimiter ~~~ or ```
    2. Match bare extension (such as ruby), or extension with period (such as .ruby), or a filename with the extension (such as filename.ruby), or any filename present in ModeSettings.xml (such as Gemfile).
    3. Continue matching up to, but not including, a newline.
    4. The nested state then just matches this newline to begin highlighting the internal mode.

### Known Issues

1. Some languages match on the same characters as the delimiters for the code fences. For example, ``` is a valid character sequence in JavaScript. Since (as far as I can tell), the internal language's matches are allowed to happen prior to the containing matches, this means it is hard to terminate in these situations. Currently, the easiest thing to do is to use ~~~ for JavaScript. For a more trivial example, I have turned off "Markdown in Markdown" since it currently seems impossible to terminate a code block fence as it is just interpreted as starting an internal code block fence.
2. For some reason, erlang causes SubEthaEdit to crash. I have turned it off too.
3. I'm not super familiar with what I should be naming these scopes.
4. We are losing "node" as a delimiter for JavaScript since it is based off of extensions and filenames now, it would be nice to have an "alias" tag or something.
5. I'm not sure if anywhere the the "key" for a language is available. For example, in the scope I use "JavaScript" since that is the mode name, whereas "js" might be preferable.

### Future Improvements
1. This is kind of the bare minimum described in #38. It for example won't work with a user's custom modes. A next step would be to have this process happen at startup time instead of at build time. However, this current system seemed like the easiest way to get a good improvement on current behavior, especially if the mode format might change soon.
2. It might be worth adding all Modes/*/ModeSettings.xml to the input files of the build phase to pick up on any changes there too.
3. It would be nice to have a better system for this sort of internal highlighting. Perhaps one exists and I'm simply not aware of it.