### PR TITLE
Migrate a few deprecated methods to reduce build warnings

### DIFF
--- a/SubEthaEdit-Mac/Source/AppController.m
+++ b/SubEthaEdit-Mac/Source/AppController.m
@@ -617,27 +617,29 @@ static AppController *sharedInstance = nil;
 			NSString *information = [NSString stringWithFormat:NSLocalizedStringWithDefaultValue(@"MODE_UPDATE_INFO_TEXT", nil, [NSBundle mainBundle],
 																								 @"\n\nUsing the updated versions removes custom changes you might have made to your mode.\n\nIf you only want to use specific new modes choose 'Show in Finder', delete the modes without modifications and reload the modes from the mode menu in SubEthaEdit.", nil)];
 			
-			NSAlert *installAlert = [NSAlert alertWithMessageText:NSLocalizedStringWithDefaultValue(@"MODE_UPDATE_MESSAGE", nil, [NSBundle mainBundle], @"Newer Modes available", nil)
-													defaultButton:NSLocalizedStringWithDefaultValue(@"MODE_UPDATE_OK_BUTTON", nil, [NSBundle mainBundle], @"Use Updated Modes", nil)
-												  alternateButton:NSLocalizedStringWithDefaultValue(@"MODE_UPDATE_REVEAL_IN_FINDER", nil, [NSBundle mainBundle], @"Show Outdated Modes", nil)
-													  otherButton:NSLocalizedString(@"Cancel", nil)
-										informativeTextWithFormat:@"%@%@%@\n", intro, modeNames,information];
-			
-			int result = [installAlert runModal];
-			
-			if (result == NSAlertAlternateReturn) { // show in finder
-				[[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:updatableModeURLs];
-				
-			} else if (result == NSAlertDefaultReturn) { // ok was selected
-				NSFileManager *fileManager = [NSFileManager defaultManager];
-				for (NSURL *url in updatableModeURLs) {
-					NSURL *urlInTrash = nil;
-					NSError *deletionError = nil;
-					//					BOOL deletionSuccess = [fileManager trashItemAtURL:destinationURL resultingItemURL:&urlInTrash error:&deletionError];
-					[fileManager trashItemAtURL:url resultingItemURL:&urlInTrash error:&deletionError];
-				}
-				[[DocumentModeManager sharedInstance] reloadDocumentModes:self];
-			}
+            NSAlert *installAlert = [[NSAlert alloc] init];
+
+            installAlert.messageText = NSLocalizedStringWithDefaultValue(@"MODE_UPDATE_MESSAGE", nil, [NSBundle mainBundle], @"Newer Modes available", nil);
+            installAlert.informativeText = [NSString stringWithFormat:@"%@%@%@\n", intro, modeNames, information];
+
+            [installAlert addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"MODE_UPDATE_OK_BUTTON", nil, [NSBundle mainBundle], @"Use Updated Modes", nil)];
+            [installAlert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
+            [installAlert addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"MODE_UPDATE_REVEAL_IN_FINDER", nil, [NSBundle mainBundle], @"Show Outdated Modes", nil)];
+
+            NSModalResponse result = [installAlert runModal];
+
+            if (result == NSAlertThirdButtonReturn) { // show in finder
+                [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:updatableModeURLs];
+            } else if (result == NSAlertFirstButtonReturn) { // ok was selected
+                NSFileManager *fileManager = [NSFileManager defaultManager];
+                for (NSURL *url in updatableModeURLs) {
+                    NSURL *urlInTrash = nil;
+                    NSError *deletionError = nil;
+                    //                    BOOL deletionSuccess = [fileManager trashItemAtURL:destinationURL resultingItemURL:&urlInTrash error:&deletionError];
+                    [fileManager trashItemAtURL:url resultingItemURL:&urlInTrash error:&deletionError];
+                }
+                [[DocumentModeManager sharedInstance] reloadDocumentModes:self];
+            }
 		}
 		
 		[defaults setObject:currentBundleVersion forKey:kSEELastKnownBundleVersion];

--- a/SubEthaEdit-Mac/Source/AppController.m
+++ b/SubEthaEdit-Mac/Source/AppController.m
@@ -942,9 +942,7 @@ static AppController *sharedInstance = nil;
         NSArray *documents=[NSApp orderedDocuments];
         if ([documents count]>0) alertWindow=[[documents objectAtIndex:0] windowForSheet];
         [newAlert beginSheetModalForWindow:alertWindow
-                             modalDelegate:nil
-                            didEndSelector:nil
-                               contextInfo:NULL];
+                         completionHandler:nil];
     }
 }
 

--- a/SubEthaEdit-Mac/Source/Debug/DebugController.m
+++ b/SubEthaEdit-Mac/Source/Debug/DebugController.m
@@ -76,7 +76,7 @@ static DebugController * sharedInstance = nil;
 
 - (void)enableDebugMenu:(BOOL)flag
 {
-    int indexOfDebugMenu = [[NSApp mainMenu] indexOfItemWithTitle:@"Debug"];
+    NSInteger indexOfDebugMenu = [[NSApp mainMenu] indexOfItemWithTitle:@"Debug"];
     
     if (flag && indexOfDebugMenu == -1) {
         NSMenuItem *debugItem = [[NSMenuItem alloc] initWithTitle:@"Debug" action:nil keyEquivalent:@""];

--- a/SubEthaEdit-Mac/Source/PlainTextDocument.m
+++ b/SubEthaEdit-Mac/Source/PlainTextDocument.m
@@ -5063,19 +5063,19 @@ const void *SEESavePanelAssociationKey = &SEESavePanelAssociationKey;
             [self setFileEncodingUndoable:NSUnicodeStringEncoding];
             if (replacementString) {
 				[textView setSelectedRange:affectedRange];
-				[textView insertText:replacementString];
+                [textView insertText:replacementString replacementRange:affectedRange];
 			}
         } else if (returnCode == NSAlertSecondButtonReturn) {
             [self setFileEncodingUndoable:NSUTF8StringEncoding];
             if (replacementString) {
 				[textView setSelectedRange:affectedRange];
-				[textView insertText:replacementString];
+                [textView insertText:replacementString replacementRange:affectedRange];
 			}
         } else if (returnCode == NSAlertFirstButtonReturn) {
             NSData *lossyData = [replacementString dataUsingEncoding:[self fileEncoding] allowLossyConversion:YES];
             if (lossyData) {
 				[textView setSelectedRange:affectedRange];
-				[textView insertText:[NSString stringWithData:lossyData encoding:[self fileEncoding]]];
+                [textView insertText:[NSString stringWithData:lossyData encoding:[self fileEncoding]] replacementRange:affectedRange];
 			}
         }
     } else if ([alertIdentifier isEqualToString:@"DocumentChangedExternallyAlert"]) {
@@ -5113,7 +5113,7 @@ const void *SEESavePanelAssociationKey = &SEESavePanelAssociationKey;
                 [invocation invoke];
             } else {
                 NSTextView *textView = [alertContext objectForKey:@"TextView"];
-                [textView insertText:[alertContext objectForKey:@"ReplacementString"]];
+                [textView insertText:[alertContext objectForKey:@"ReplacementString"] replacementRange:textView.selectedRange];
             }
         }
     } else if ([alertIdentifier isEqualToString:@"MixedLineEndingsAlert"]) {
@@ -5131,10 +5131,10 @@ const void *SEESavePanelAssociationKey = &SEESavePanelAssociationKey;
             [[alert window] orderOut:self];
             NSMutableString *mutableString = [[NSMutableString alloc] initWithString:replacementString];
             [mutableString convertLineEndingsToLineEndingString:[self lineEndingString]];
-            [textView insertText:mutableString];
+            [textView insertText:mutableString replacementRange:textView.selectedRange];
             [mutableString release];
         } else if (returnCode == NSAlertSecondButtonReturn) {
-            [textView insertText:replacementString];
+            [textView insertText:replacementString replacementRange:textView.selectedRange];
         }
     }
 }
@@ -6282,7 +6282,7 @@ const void *SEESavePanelAssociationKey = &SEESavePanelAssociationKey;
                 }
             }
             if (indentString) {
-                [aTextView insertText:[NSString stringWithFormat:@"%@%@%@",[self lineEndingString],indentString, postString]];
+                [aTextView insertText:[NSString stringWithFormat:@"%@%@%@",[self lineEndingString],indentString, postString] replacementRange:aTextView.selectedRange];
                 if ([postString length] > 0) {
                 	// move selection back to the desired position
                 	NSRange selectedRange = [aTextView selectedRange];
@@ -6290,7 +6290,7 @@ const void *SEESavePanelAssociationKey = &SEESavePanelAssociationKey;
                 	[aTextView setSelectedRange:selectedRange];
                 }
             } else {
-                [aTextView insertText:[self lineEndingString]];
+                [aTextView insertText:[self lineEndingString] replacementRange:aTextView.selectedRange];
             }
             return YES;
 
@@ -6346,12 +6346,12 @@ const void *SEESavePanelAssociationKey = &SEESavePanelAssociationKey;
 					}
         		}
         	}
-        	if (!I_flags.usesTabs) {
+            if (!I_flags.usesTabs) {
 				// when we have a tab we have to find the last linebreak
 				NSRange lineRange=[[[self textStorage] string] lineRangeForRange:affectedRange];
 				NSString *replacementString=[@" " stringByPaddingToLength:I_tabWidth-((affectedRange.location-lineRange.location)%I_tabWidth)
 															   withString:@" " startingAtIndex:0];
-				[aTextView insertText:replacementString];
+                [aTextView insertText:replacementString replacementRange:aTextView.selectedRange];
 				return YES;
 			}
 			return NO; // do the default behaviour

--- a/SubEthaEdit-Mac/Source/PlainTextEditor.m
+++ b/SubEthaEdit-Mac/Source/PlainTextEditor.m
@@ -1933,9 +1933,9 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
 
                 [self selectRange:NSUnionRange(whitespaceRange, selectedRange)];
                 // NSLog(@"%s inserting ||%@||", __FUNCTION__, autoend);
-                [I_textView insertText:autoend];
+                [I_textView insertText:autoend replacementRange:I_textView.selectedRange];
             } else {
-                [I_textView insertText:autoend];
+                [I_textView insertText:autoend replacementRange:I_textView.selectedRange];
             }
         } else {
             NSBeep();

--- a/SubEthaEdit-Mac/Source/PlainTextEditor.m
+++ b/SubEthaEdit-Mac/Source/PlainTextEditor.m
@@ -59,8 +59,8 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
 - (NSMenu *)bottomPart {
     NSMenu *newMenu = [[NSMenu new] autorelease];
     NSArray *items = [self itemArray];
-    int count = [items count];
-    int index = count - 1;
+    NSUInteger count = [items count];
+    NSInteger index = count - 1;
 
     while (index >= 0) {
         if ([[items objectAtIndex:index] isSeparatorItem]) {
@@ -952,8 +952,8 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
 }
 
 
-- (int)dentLineInTextView:(NSTextView *)aTextView withRange:(NSRange)aLineRange in:(BOOL)aIndent {
-    int changedChars = 0;
+- (NSInteger)dentLineInTextView:(NSTextView *)aTextView withRange:(NSRange)aLineRange in:(BOOL)aIndent {
+    NSInteger changedChars = 0;
     static NSCharacterSet *spaceTabSet = nil;
 
     if (!spaceTabSet) {
@@ -970,7 +970,7 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
     if ([document usesTabs]) {
         if (aIndent) {
             // replace spaces with tabs and add one tab
-            unsigned lastCharacter = aLineRange.location;
+            NSUInteger lastCharacter = aLineRange.location;
 
             while (lastCharacter < NSMaxRange(aLineRange) &&
                    [spaceTabSet characterIsMember:[string characterAtIndex:lastCharacter]]) {
@@ -1003,7 +1003,7 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
         } else {
             if ([string length] > aLineRange.location) {
                 // replace spaces with tabs and remove one tab or the remaining whitespace
-                unsigned lastCharacter = aLineRange.location;
+                NSUInteger lastCharacter = aLineRange.location;
 
                 while (lastCharacter < NSMaxRange(aLineRange) &&
                        [spaceTabSet characterIsMember:[string characterAtIndex:lastCharacter]])
@@ -1046,7 +1046,7 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
             }
         }
     } else {
-        unsigned firstCharacter = aLineRange.location;
+        NSUInteger firstCharacter = aLineRange.location;
 
         // replace tabs with spaces
         while (firstCharacter < NSMaxRange(aLineRange)) {
@@ -1159,8 +1159,8 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
 						lineRange.location = NSMaxRange(affectedRange) - 1;
 						lineRange.length = 1;
 						lineRange = [string lineRangeForRange:lineRange];
-						int result = 0;
-						int changedLength = 0;
+						NSInteger result = 0;
+						NSInteger changedLength = 0;
 
 						while (!DisjointRanges(lineRange, affectedRange)) {
 							result = [self dentLineInTextView:aTextView withRange:lineRange in:aIndent];

--- a/SubEthaEdit-Mac/Source/SEEDocumentController.m
+++ b/SubEthaEdit-Mac/Source/SEEDocumentController.m
@@ -1753,12 +1753,12 @@ struct ModificationInfo
 						   name];
 		}
 
-		NSAlert *infoAlert = [NSAlert alertWithMessageText:messageText
-											 defaultButton:NSLocalizedString(@"OK", nil)
-										   alternateButton:nil
-											   otherButton:nil
-								 informativeTextWithFormat:@""];
-		
+        NSAlert *infoAlert = [[NSAlert alloc] init];
+
+        infoAlert.messageText = messageText;
+
+        [infoAlert addButtonWithTitle:@"OK"];
+
         [infoAlert setAlertStyle:NSInformationalAlertStyle];
         [infoAlert runModal];
     }

--- a/SubEthaEdit-Mac/Source/SEEDocumentController.m
+++ b/SubEthaEdit-Mac/Source/SEEDocumentController.m
@@ -139,11 +139,11 @@ NSString * const kSEETypeSEEMode = @"de.codingmonkeys.subethaedit.seemode";
     [alert setInformativeText:NSLocalizedString(@"Merging windows moves all open tabs and windows into a single, tabbed editor window. This cannot be undone.", nil)];
     [alert addButtonWithTitle:NSLocalizedString(@"Merge", nil)];
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
-    int response = [alert runModal];
+    NSModalResponse response = [alert runModal];
     if (NSAlertFirstButtonReturn == response) {
         PlainTextWindowController *targetWindowController = [self activeWindowController];
         id document = [targetWindowController document];
-        int count = [I_windowControllers count];
+        NSUInteger count = [I_windowControllers count];
         while (--count >= 0) {
             PlainTextWindowController *sourceWindowController = [I_windowControllers objectAtIndex:count];
             if (sourceWindowController != targetWindowController) {
@@ -1459,7 +1459,7 @@ NSString * const kSEETypeSEEMode = @"de.codingmonkeys.subethaedit.seemode";
     }
     
     if (shouldWait) { // this is for new documents and pipes, existing documents are handled above
-        int count = [documents count];
+        NSUInteger count = [documents count];
         if (count > 0) {
             [command suspendExecution];
             [I_suspendedSeeScriptCommands setObject:command forKey:identifier]; // this may replace the command added by existing documents earlier, but is the same command anyway.

--- a/SubEthaEdit-Mac/Source/SEEDocumentController.m
+++ b/SubEthaEdit-Mac/Source/SEEDocumentController.m
@@ -1692,22 +1692,26 @@ struct ModificationInfo
 	}
 
 	// show alert
-	NSAlert *installAlert = [NSAlert alertWithMessageText:titleText
-											defaultButton:NSLocalizedStringWithDefaultValue(@"MODE_INSTALL_OK_BUTTON", nil, [NSBundle mainBundle], @"Install", nil)
-										  alternateButton:NSLocalizedStringWithDefaultValue(@"MODE_INSTALL_SHOW_CONTENT_BUTTON", nil, [NSBundle mainBundle], @"Show Package Contents", nil)
-											  otherButton:NSLocalizedString(@"Cancel", nil)
-								informativeTextWithFormat:@"%@", informativeText];
-	
-	int result = [installAlert runModal];
-	if (result == NSAlertAlternateReturn) { // show package contents
+    NSAlert *installAlert = [[NSAlert alloc] init];
+
+    installAlert.messageText = titleText;
+    installAlert.informativeText = informativeText;
+
+    [installAlert addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"MODE_INSTALL_OK_BUTTON", nil, [NSBundle mainBundle], @"Install", nil)];
+    [installAlert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
+    [installAlert addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"MODE_INSTALL_SHOW_CONTENT_BUTTON", nil, [NSBundle mainBundle], @"Show Package Contents", nil)];
+
+	NSModalResponse result = [installAlert runModal];
+
+    if (result == NSAlertThirdButtonReturn) { // show package contents
 		NSString *resourcePath = [modeBundle resourcePath];
 		if (resourcePath) {
 			[[NSWorkspace sharedWorkspace] selectFile:resourcePath inFileViewerRootedAtPath:[resourcePath stringByDeletingLastPathComponent]];
 		}
 	
-	} else if (result == NSAlertDefaultReturn) { // ok was selected
+	} else if (result == NSAlertFirstButtonReturn) { // ok was selected
         BOOL success = NO;
-		
+
 		NSURL *destinationURL = [[DocumentModeManager sharedInstance] urlForWritingModeWithName:[modeBundle objectForInfoDictionaryKey:@"CFBundleName"]];
 		NSString *destinationPath = [destinationURL path];
 		

--- a/SubEthaEdit-Mac/Source/SEEFindAndReplaceContext.m
+++ b/SubEthaEdit-Mac/Source/SEEFindAndReplaceContext.m
@@ -385,7 +385,7 @@ typedef NS_ENUM(uint8_t, SEESearchRangeDirection) {
 			[[document session] pauseProcessing];
 			[[document documentUndoManager] beginUndoGrouping];
 
-			[self.targetTextView insertText:replaceString];
+            [self.targetTextView insertText:replaceString replacementRange:self.targetTextView.selectedRange];
 			
 			[[document documentUndoManager] endUndoGrouping];
 			[[document session] startProcessing];

--- a/SubEthaEdit-Mac/Source/SyntaxDefinition.m
+++ b/SubEthaEdit-Mac/Source/SyntaxDefinition.m
@@ -1037,7 +1037,7 @@ static NSString * const StateDictionaryUseAutocompleteFromModeKey      = @"useau
     }
 
 
-    int combinedStringLength = [combinedString length];
+    NSUInteger combinedStringLength = [combinedString length];
     if ((combinedStringLength>1)||(endString)) {
         if (endString) { // Any states except the default
             [combinedString appendString:[NSString stringWithFormat:@"(?<seeinternalgroup4242>%@)",endString]];

--- a/SubEthaEdit-Mac/Source/SyntaxHighlighter.m
+++ b/SubEthaEdit-Mac/Source/SyntaxHighlighter.m
@@ -238,7 +238,7 @@ static unsigned int trimmedStartOnLevel = UINT_MAX;
 					[stack addObject:[NSDictionary dictionaryWithObjectsAndKeys:[subState objectForKey:@"id"], @"state", indentLevel, kSyntaxHighlightingIndentLevelName, nil]];
 				}
                 
-                unsigned int level = [stack count];
+                NSUInteger level = [stack count];
 				
                 if ((level==trimmedStartOnLevel+1)||(level==trimmedStartOnLevel)) { // Was previous start a trimmed one?
 //					[I_stringLock lock];
@@ -307,7 +307,7 @@ static unsigned int trimmedStartOnLevel = UINT_MAX;
                 NSRange matchedEndRange = [delimiterMatch rangeOfSubstringNamed:@"trimmedend"];
                 if (matchedEndRange.location != NSNotFound) delimiterRange = matchedEndRange;
                 
-                unsigned int level = [stack count];
+                NSUInteger level = [stack count];
                 if (level>trimmedStartOnLevel) {
 //					[I_stringLock lock];
                     [aString removeAttribute:kSyntaxHighlightingFoldDelimiterName range:stateRange];
@@ -510,7 +510,7 @@ static unsigned int trimmedStartOnLevel = UINT_MAX;
     // Check if the string after the area we just colored matches up
     // Make it dirty if there is a logical glitch
     
-    int nextIndex = NSMaxRange(aRange);
+    NSInteger nextIndex = NSMaxRange(aRange);
     if (nextIndex >= [theString length]) return;
     
     if (([aString attribute:kSyntaxHighlightingIsCorrectAttributeName atIndex:nextIndex effectiveRange:nil])) {
@@ -518,9 +518,9 @@ static unsigned int trimmedStartOnLevel = UINT_MAX;
         BOOL leftIsEnd = [[aString attribute:kSyntaxHighlightingStateDelimiterName atIndex:nextIndex-1 effectiveRange:nil] isEqualTo:kSyntaxHighlightingStateDelimiterEndValue];
         BOOL rightIsStart = [[aString attribute:kSyntaxHighlightingStateDelimiterName atIndex:nextIndex effectiveRange:nil] isEqualTo:kSyntaxHighlightingStateDelimiterStartValue];
         NSArray *leftStack = [aString attribute:kSyntaxHighlightingStackName atIndex:nextIndex-1 effectiveRange:nil];
-        int leftCount = [leftStack count];
+        NSUInteger leftCount = [leftStack count];
         NSArray *rightStack = [aString attribute:kSyntaxHighlightingStackName atIndex:nextIndex effectiveRange:nil];
-        int rightCount = [rightStack count];
+        NSUInteger rightCount = [rightStack count];
         
         // Same stack, no ends and begins or both an end and a begin
         if ([leftStack isEqualToArray:rightStack]) {
@@ -532,7 +532,7 @@ static unsigned int trimmedStartOnLevel = UINT_MAX;
             if ([definition state:[[rightStack lastObject] objectForKey:@"state"] includesState:[[leftStack lastObject] objectForKey:@"state"]]) matchesUp = YES;
         }
         // Left stack exactly one smaller than right and there is a start => leftState must include rightState
-        else if ((leftCount == rightCount - 1) && rightIsStart) {  
+        else if ((leftCount + 1 == rightCount) && rightIsStart) {
             if ([definition state:[[leftStack lastObject] objectForKey:@"state"] includesState:[[rightStack lastObject] objectForKey:@"state"]]) matchesUp = YES;
         }
 


### PR DESCRIPTION
In this PR I've tried to start tackling some of the deprecated methods that are generating a bunch of warnings in XCode. Specifically I've fixed:

1. I believe all the warnings in FindReplaceController.m (updated beginSheetModalForWindow:)
2. I believe all the warnings in PlainTextWindowController.m (updated beginSheetModalForWindow:)
3. I believe all the warnings in SEEDocumentController.m (beginSheetModalForWindow: and alertWithMessageText:)
4. I've also converted a bunch of ints and longs to NSInteger and NSUInteger as I had that warning turned on before. This is pretty straight forward most the time, except I've changed a (a == b - 1) to (a + 1 == b) [here](https://github.com/subethaedit/SubEthaEdit/compare/develop...tolmasky:fix-deprecation-warnings?expand=1#diff-bd91d183f9dc0ba8b9f7ec5893f1c67eR521) in order to be able to use NSUInteger.

This is a partial fix for #66.
