### PR TITLE
[FIX #79] Attach the open file menu to the topBarView

### DIFF
--- a/SubEthaEdit-Mac/Source/PlainTextEditor.m
+++ b/SubEthaEdit-Mac/Source/PlainTextEditor.m
@@ -2157,11 +2157,11 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
                     break;
                 }
             }
-            NSRect frame = [self.O_editorView frame];
-            frame.size.width = 50;
-            frame.origin.y = frame.size.height - 20;
-            frame.size.height = 20;
-            [s_cell performClickWithFrame:frame inView:self.O_editorView];
+
+            NSView * controlView = self.topBarViewController.view;
+            NSRect frame = NSMakeRect(0, 0, 50, controlView.frame.size.height);
+            [s_cell performClickWithFrame:frame inView:controlView];
+            
             return;
         }
         else if ([self showsBottomStatusBar])


### PR DESCRIPTION
Fixes #79 

By default, AppKit tries to match the position of the selected item of a menu with the frame specified in `[s_cell performClickWithFrame:frame inView:controlView]` However, if there is insufficient screen space, the menu will displayed below the `controlView` which is in case of the previously used `O_editorView` outside of the visible screen frame. To overcome this issue, the topBar is now being used as `controlView` placing the menu in case of insufficient space below the top bar