### PR TITLE
Fairly simple fix for #62 (auto-indent broken in bash), just look for…

### DIFF
--- a/SubEthaEdit-Mac/Modes/bash.seemode/Contents/Resources/SyntaxDefinition.xml
+++ b/SubEthaEdit-Mac/Modes/bash.seemode/Contents/Resources/SyntaxDefinition.xml
@@ -481,7 +481,7 @@
 
             <state id="if then fi Block" type="block" foldable="yes" indent="yes" scope="meta.block">
                 <begin><regex>(?&lt;![^;\s])then(?!\S)</regex></begin>
-                <end><regex>(?&lt;!\S)fi(?!\S)</regex></end>
+                <end><regex>(?&lt;!\S)elif|fi(?!\S)</regex></end>
                 <import/>
             </state>
 


### PR DESCRIPTION
… elif or fi instead of just fi to close and if block.

Closes #62.

Reviewed by @tolmasky.