### PR TITLE
[FIX #118] comment/uncomment can crash the whole app

### DIFF
--- a/SubEthaEdit-Mac/Source/FoldableTextStorage.m
+++ b/SubEthaEdit-Mac/Source/FoldableTextStorage.m
@@ -567,11 +567,8 @@ typedef union {
 		}
 
 	} else {
-//		unsigned origLen = [I_fullTextStorage length];
 		[I_fullTextStorage replaceCharactersInRange:aRange withString:aString synchronize:YES];
-//		[self edited:NSTextStorageEditedCharacters range:aRange 
-//			  changeInLength:[I_fullTextStorage length] - origLen];
-	}    
+	}
 
 	if (I_internalAttributedString && [I_sortedFoldedTextAttachments count] == 0) {
 		[self removeInternalStorageString];
@@ -597,8 +594,7 @@ typedef union {
 	} else {
 		[I_fullTextStorage setAttributes:attributes range:[self fullRangeForFoldedRange:aRange] synchronize:YES];
 	}
-	[self edited:NSTextStorageEditedAttributes range:aRange 
-		  changeInLength:0];
+	[self edited:NSTextStorageEditedAttributes range:aRange changeInLength:0];
 }
 
 - (void)setAttributes:(NSDictionary *)attributes range:(NSRange)aRange {
@@ -607,8 +603,7 @@ typedef union {
 
 
 // convenience method
-- (void)replaceCharactersInRange:(NSRange)inRange withAttributedString:(NSAttributedString *)inAttributedString synchronize:(BOOL)inSynchronizeFlag 
-{
+- (void)replaceCharactersInRange:(NSRange)inRange withAttributedString:(NSAttributedString *)inAttributedString synchronize:(BOOL)inSynchronizeFlag  {
 //	NSLog(@"%s",__FUNCTION__);
 	[self beginEditing];
 	if (I_internalAttributedString) {
@@ -662,7 +657,7 @@ typedef union {
 //	NSLog(@"%s %@ %@ lengthChange %d",__FUNCTION__, NSStringFromRange(inRange), inString, [inString length] - inRange.length);
 
 	if (!I_internalAttributedString) {
-		[self edited:NSTextStorageEditedCharacters range:inRange changeInLength:[inString length] - inRange.length];
+		[self edited:NSTextStorageEditedCharacters range:inRange changeInLength:inString.length - inRange.length];
 	} else {
 		// lots of cases have to be considered here
 		// - changed range does not intersect with any folding -> straight through

--- a/SubEthaEdit-Mac/Source/GutterRulerView.h
+++ b/SubEthaEdit-Mac/Source/GutterRulerView.h
@@ -16,4 +16,6 @@
 	NSPoint I_lastMouseDownPoint;
 }
 
+@property (nonatomic) BOOL suspendDrawing;
+
 @end

--- a/SubEthaEdit-Mac/Source/GutterRulerView.m
+++ b/SubEthaEdit-Mac/Source/GutterRulerView.m
@@ -130,7 +130,7 @@ FOUNDATION_STATIC_INLINE void DrawIndicatorForDepthInRect(int aDepth, NSRect aRe
     
 	[colors[@"GutterBackground"] set];
 	NSRectFill(aRect);
-		
+    
 	if (!drawLineNumber) {
 		CGFloat linenumberFontSize=9.;
 			NSFont *font=[NSFont fontWithName:@"Tahoma" size:linenumberFontSize];
@@ -194,7 +194,11 @@ FOUNDATION_STATIC_INLINE void DrawIndicatorForDepthInRect(int aDepth, NSRect aRe
 	fullFoldingAreaRect.size.width = foldingAreaRect.size.width;
 	[colors[@"GutterMin"] set];
 	NSRectFill(fullFoldingAreaRect);
-	
+
+    if (self.suspendDrawing) {
+        return;
+    }
+
 	
     if ([textStorage length]) {
         boundingRect=NSMakeRect(0,0,0,0);

--- a/SubEthaEdit-Mac/Source/NSOperationQueue+TCMAdditions.h
+++ b/SubEthaEdit-Mac/Source/NSOperationQueue+TCMAdditions.h
@@ -9,16 +9,23 @@
 
 /*!
  Performs aBlock on the main Thread after the given delay. Not cancellable. You can simulate cancel by checking a condition at the start of your block, and doing nothing otherwise. Uses dispatch_after directly, not using NSOperationQueue.
- @param aBlock the block to be performed
- @param aDelay the delay in seconds
+ @param block the block to be performed
+ @param delay the delay in seconds
  */
-+ (void)TCM_performBlockOnMainQueue:(dispatch_block_t)aBlock afterDelay:(NSTimeInterval)aDelay;
++ (void)TCM_performBlockOnMainQueue:(dispatch_block_t)block afterDelay:(NSTimeInterval)delay;
 
 /*!
- Ensures the execution of the aBlock given to be on the main thread. Useful for convenience if you are in callbacks that might not be on the main thread but need to crossover. Uses dispatch_async on dispatch_get_main_queue().
- @param aBlock the block to be performed
+ Ensures the execution of the block given to be on the main thread. Useful for convenience if you are in callbacks that might not be on the main thread but need to crossover. Uses dispatch_async on dispatch_get_main_queue().
+ @param block the block to be performed
  @return NO if called from the main thread, and the block was executed synchronously. YES otherwise
  */
-+ (BOOL)TCM_performBlockOnMainThreadIsAsynchronous:(dispatch_block_t)aBlock;
++ (BOOL)TCM_performBlockOnMainThreadIsAsynchronous:(dispatch_block_t)block;
+
+
+/*!
+ Ensures the execution of the block given to be on the main thread. Useful for convenience if you are in callbacks that might not be on the main thread but need to crossover. Uses dispatch_sync on dispatch_get_main_queue() if necessary. Always synchronous.
+ @param block the block to be performed
+ */
++ (void)TCM_performBlockOnMainThreadSynchronously:(dispatch_block_t)block;
 
 @end

--- a/SubEthaEdit-Mac/Source/NSOperationQueue+TCMAdditions.m
+++ b/SubEthaEdit-Mac/Source/NSOperationQueue+TCMAdditions.m
@@ -26,4 +26,14 @@
 	}
 }
 
+// TODO: ensure this can't deadlock ever
++ (void)TCM_performBlockOnMainThreadSynchronously:(dispatch_block_t)block {
+    if ([NSThread isMainThread]) {
+        block();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), block);
+    }
+
+}
+
 @end

--- a/SubEthaEdit-Mac/Source/PlainTextDocument.m
+++ b/SubEthaEdit-Mac/Source/PlainTextDocument.m
@@ -6795,13 +6795,19 @@ const void *SEESavePanelAssociationKey = &SEESavePanelAssociationKey;
 }
 
 - (void)scriptWrapperWillRunScriptNotification:(NSNotification *)aNotification {
-    [[self session] pauseProcessing];
-    I_flags.syntaxHighlightingIsSuspended = YES;
+    // Needs to be called synchronously on the main queue to ensure integrity
+    [NSOperationQueue TCM_performBlockOnMainThreadSynchronously:^{
+        [[self session] pauseProcessing];
+        self->I_flags.syntaxHighlightingIsSuspended = YES;
+    }];
 }
 
 - (void)scriptWrapperDidRunScriptNotification:(NSNotification *)aNotification {
-    I_flags.syntaxHighlightingIsSuspended = NO;
-    [[self session] startProcessing];
+    // Needs to be main thread, but asynchronously is ok too
+    [NSOperationQueue TCM_performBlockOnMainThreadIsAsynchronous:^{
+        self->I_flags.syntaxHighlightingIsSuspended = NO;
+        [[self session] startProcessing];
+    }];
 }
 
 #ifndef TCM_NO_DEBUG

--- a/SubEthaEdit-Mac/Source/PlainTextEditor.h
+++ b/SubEthaEdit-Mac/Source/PlainTextEditor.h
@@ -19,6 +19,7 @@ extern NSString * const PlainTextEditorDidChangeSearchScopeNotification;
 
 @interface PlainTextEditor : NSResponder <NSTextViewDelegate> 
 
+@property (nonatomic) BOOL isSuspendingGutterDrawing;
 @property (nonatomic, readonly) BOOL hasBottomOverlayView;
 @property (nonatomic, readonly) BOOL hasTopOverlayView;
 // bottom status bar binding values

--- a/SubEthaEdit-Mac/Source/PlainTextEditor.m
+++ b/SubEthaEdit-Mac/Source/PlainTextEditor.m
@@ -1716,6 +1716,18 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
 	}
 }
 
+- (BOOL)isSuspendingGutterDrawing {
+    return ((GutterRulerView *)O_scrollView.verticalRulerView).suspendDrawing;
+}
+
+- (void)setIsSuspendingGutterDrawing:(BOOL)isSuspendingGutterDrawing {
+    GutterRulerView *rulerView = O_scrollView.verticalRulerView;
+    [rulerView setSuspendDrawing:isSuspendingGutterDrawing];
+    if (!isSuspendingGutterDrawing) {
+        [rulerView setNeedsDisplay:YES];
+    }
+}
+
 - (BOOL)showsGutter {
     return [O_scrollView rulersVisible];
 }

--- a/SubEthaEdit-Mac/Source/ScriptWrapper.m
+++ b/SubEthaEdit-Mac/Source/ScriptWrapper.m
@@ -82,61 +82,63 @@ NSString * const ScriptWrapperDidRunScriptNotification =@"ScriptWrapperDidRunScr
     }
 }
 
-- (void)_delayedExecute
-{
+- (void)_delayedExecute {
     @autoreleasepool {
         BOOL isInsideAppBundle = [[_URL path] hasPrefix:[[[NSBundle mainBundle] bundleURL] path]];
         
-        [[NSNotificationCenter defaultCenter] postNotificationName:ScriptWrapperWillRunScriptNotification object:self];
-
-        NSDictionary<NSString *, id> *errorDictionary;
-        [self executeAndReturnError:&errorDictionary];
-        if (errorDictionary) {
-            if (isInsideAppBundle &&
-                [errorDictionary[@"NSAppleScriptErrorMessage"] rangeOfString:@"LSOpenURLsWithRole"].location != NSNotFound)  {
-                NSURL *userScriptsDirectory = [[NSFileManager defaultManager] URLForDirectory:NSApplicationScriptsDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:nil];
-                NSString *lastPathComponent = [_URL lastPathComponent];
-                NSURL *userScriptURL = [userScriptsDirectory URLByAppendingPathComponent:lastPathComponent];
-                if ([[NSFileManager defaultManager] isReadableFileAtPath:userScriptURL.path]) {
-                    // Be kind and just use that script.
-                    if ([self _loadScriptAtURL:userScriptURL]) {
-                        NSUserScriptTask *userScript = [[NSUserScriptTask alloc] initWithURL:_URL error:nil];
-                        [userScript executeWithCompletionHandler:nil];
+        @synchronized ([ScriptWrapper class]) { // only one script in parallel
+            
+            NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
+            [defaultCenter postNotificationName:ScriptWrapperWillRunScriptNotification object:self];
+            
+            NSDictionary<NSString *, id> *errorDictionary;
+            [self executeAndReturnError:&errorDictionary];
+            if (errorDictionary) {
+                if (isInsideAppBundle &&
+                    [errorDictionary[@"NSAppleScriptErrorMessage"] rangeOfString:@"LSOpenURLsWithRole"].location != NSNotFound)  {
+                    NSURL *userScriptsDirectory = [[NSFileManager defaultManager] URLForDirectory:NSApplicationScriptsDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:nil];
+                    NSString *lastPathComponent = [_URL lastPathComponent];
+                    NSURL *userScriptURL = [userScriptsDirectory URLByAppendingPathComponent:lastPathComponent];
+                    if ([[NSFileManager defaultManager] isReadableFileAtPath:userScriptURL.path]) {
+                        // Be kind and just use that script.
+                        if ([self _loadScriptAtURL:userScriptURL]) {
+                            NSUserScriptTask *userScript = [[NSUserScriptTask alloc] initWithURL:_URL error:nil];
+                            [userScript executeWithCompletionHandler:nil];
+                        }
+                    } else {
+                        // Help the user copy the script
+                        [[NSWorkspace sharedWorkspace] selectFile:_URL.path inFileViewerRootedAtPath:[_URL.path stringByDeletingLastPathComponent]];
+                        [[NSWorkspace sharedWorkspace] openURL:userScriptsDirectory];
+                        id modifiedError = [errorDictionary mutableCopy];
+                        // FIXME: this needs localisation
+                        modifiedError[@"NSAppleScriptErrorBriefMessage"] = [NSString stringWithFormat:@"The script '%@' needs access to other applications.", lastPathComponent];
+                        modifiedError[@"NSAppleScriptErrorMessage"] = [NSString stringWithFormat:@"Please copy '%@' from the opened Application Bundle script folder into the user script folder we also opened for you.", lastPathComponent];
+                        // slight delay, so the SubEthaEdit error comes out on top of the rest.
+                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                            [[AppController sharedInstance] reportAppleScriptError:modifiedError];
+                        });
                     }
                 } else {
-                    // Help the user copy the script
-                    [[NSWorkspace sharedWorkspace] selectFile:_URL.path inFileViewerRootedAtPath:[_URL.path stringByDeletingLastPathComponent]];
-                    [[NSWorkspace sharedWorkspace] openURL:userScriptsDirectory];
-                    id modifiedError = [errorDictionary mutableCopy];
-                    // FIXME: this needs localisation
-                    modifiedError[@"NSAppleScriptErrorBriefMessage"] = [NSString stringWithFormat:@"The script '%@' needs access to other applications.", lastPathComponent];
-                    modifiedError[@"NSAppleScriptErrorMessage"] = [NSString stringWithFormat:@"Please copy '%@' from the opened Application Bundle script folder into the user script folder we also opened for you.", lastPathComponent];
-                    // slight delay, so the SubEthaEdit error comes out on top of the rest.
-                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                        [[AppController sharedInstance] reportAppleScriptError:modifiedError];
-                    });
+                    [[AppController sharedInstance] reportAppleScriptError:errorDictionary];
                 }
-            } else {
-                [[AppController sharedInstance] reportAppleScriptError:errorDictionary];
             }
+            [defaultCenter postNotificationName:ScriptWrapperDidRunScriptNotification object:self userInfo:errorDictionary];
         }
-        [[NSNotificationCenter defaultCenter] postNotificationName:ScriptWrapperDidRunScriptNotification object:self userInfo:errorDictionary];
+        
     }
 }
 
 - (void)performScriptAction:(id)aSender {
-    if (([[NSApp currentEvent] type] != NSEventTypeKeyDown) &&
-        ([[NSApp currentEvent] modifierFlags] & NSEventModifierFlagOption)) {
+    NSEvent *event = NSApp.currentEvent;
+    if (([event type] != NSEventTypeKeyDown) &&
+        ([event modifierFlags] & NSEventModifierFlagOption)) {
         [self revealSource];
     } else {
         NSURL *userScriptDirectory = [[NSFileManager defaultManager] URLForDirectory:NSApplicationScriptsDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:NO error:nil];
-        if (userScriptDirectory && [[[_URL URLByStandardizingPath] path] hasPrefix:[[userScriptDirectory URLByStandardizingPath] path]])
-        {
+        if (userScriptDirectory && [[[_URL URLByStandardizingPath] path] hasPrefix:[[userScriptDirectory URLByStandardizingPath] path]]) {
             NSUserScriptTask *userScript = [[NSUserScriptTask alloc] initWithURL:_URL error:nil];
             [userScript executeWithCompletionHandler:nil];
-        }
-        else
-        {
+        } else {
             [self performSelectorInBackground:@selector(_delayedExecute) withObject:nil];
         }
     }


### PR DESCRIPTION
The underlying root cause seems to be that the gutter ruler view actually gets too many draw rects during editing, querying a lot of in flight layout information it shouldn't. However, this seems to be triggered by the layer backedness of things and I couldn't find a way to quickly mitigate that.

So what are we doing now:
- make sure the scriptWrapperWillRun/DidRun calls are properly bounced to the main thread as they should have been always
- disable the complex text storage querying drawing code of the gutter ruler view during the execution of scripts
- making sure only one script is running at a time by adding a global lock to scriptwrapper (otherwise the comment/uncomment scripts could nest and cause super havoc)