### PR TITLE
Fix for #106. We don't need our own custom queueing system since Cocoa does this already.

### DIFF
--- a/SubEthaEdit-Mac/Source/PlainTextDocument.h
+++ b/SubEthaEdit-Mac/Source/PlainTextDocument.h
@@ -171,8 +171,6 @@ extern NSString * const PlainTextDocumentDidSaveShouldReloadWebPreviewNotificati
 - (void)presentPromotionAlertForTextView:(NSTextView *)textView insertionString:(NSString *)insertionString affectedRange:(NSRange)affectedRange;
 - (void)conditionallyEditAnyway:(void (^)(PlainTextDocument *))completionHandler;
 
-- (void)presentScheduledAlertForWindow:(NSWindow *)window;
-
 - (IBAction)newView:(id)aSender;
 //- (IBAction)goIntoBundles:(id)sender;
 //- (IBAction)showHiddenFiles:(id)sender;

--- a/SubEthaEdit-Mac/Source/PlainTextDocument.m
+++ b/SubEthaEdit-Mac/Source/PlainTextDocument.m
@@ -807,15 +807,15 @@ static NSString *tempFileName(NSString *origPath) {
 - (void)presentAlert:(NSAlert *)alert completionHandler:(void (^)(NSModalResponse returnCode))completionHandler {
     if (alert == nil) { return; }
 
-    NSArray * orderedWindows = NSApp.orderedWindows;
-    NSSet * candidateWindows = [NSSet setWithArray:[self.windowControllers valueForKey:@"window"]];
+    NSArray *orderedWindows = NSApp.orderedWindows;
+    NSSet *candidateWindows = [NSSet setWithArray:[self.windowControllers valueForKey:@"window"]];
 
     NSUInteger index = [orderedWindows indexOfObjectPassingTest:
-                        ^(NSWindow * window, NSUInteger idx, BOOL * stop) {
+                        ^(NSWindow *window, NSUInteger idx, BOOL *_stop) {
                             return [candidateWindows containsObject:window];
                         }];
 
-    NSWindow * window = orderedWindows[index];
+    NSWindow *window = orderedWindows[index];
 
     [window makeKeyAndOrderFront:self];
     [alert beginSheetModalForWindow:window completionHandler:completionHandler];


### PR DESCRIPTION
I had originally been working on a bigger fix that would also attack #98, but it became clear that were a number of overlapping issues and it made more sense to address these individually.

This fix solely addresses "queued" alerts, IOW when a sheet needs to be shown but one is already present. The fix here is to just assume that situation never happens, and I'll explain why here:

1. Given that `beginSheetModalForWindow:completionHandler:` dismisses the sheet before even calling the handler (.vs the old API that required you to do it manually), it's not clear it's even trivially possible ot enter this situation simply by triggering two consecuttive alerts. It is of course still *possible* in other situations, but...
2. NSWindow already keeps an internal queue of sheets, so calling `beginSheetModalForWindow:completionHandler:` twice is not per se a problem.

As such, this fix merely finishes removing the `self.presentScheduledAlertForWindow` system from before, and you can confirm that the two consecutive alerts work now. This fix also cleans up the rest of the `presentAlert:completionHandler:` and replaces an `O(N*M)` loop with an `O(N)` loop. As you'll see in the code, we no longer do any fancier calculation than simply finding the front-most window associated with the document - this is because showing another sheet on top of this merely uses the built-in queue, and more importantly, I think it would be a weird state to "split" the sheets amongst other available windows associated with the document, merely because they are more "ready" to do so.

Now, returning to the larger fix, the issue at hand is that there are *three* inter-related, but separate, concerns:

1. The possibility of multiple alerts being queued (for example, it is possible to get multiple messages from the collaborative editing that would queue up).
2. The possibility that alerts need to be shown on *background tabs*, and the best way to handle this.
3. The possibility that an alert needs to be shown on a document that is being represented by *multiple windows*.

As stated previously, this fix addresses (1), and IMO leaves things in a fine state if we needed to ship *today*. That beeing said, I agree that it would be nice to have a better answer for (2) and (3), and thinking about them have also lead me to consider other bugs/situations that exist even in the code before.

To sum up, most the problems arise from the fact that Cocoa considers sheets to be a *window-level* concept instead of a *document-level* concept, and the fact that Cocoa makes it impossible to show a sheet in the background. This leads to the situations I mentioned earlier. The reality is that these document-level sheets should (conceptually) be shown on *all* the windows associated with a document, and block interaction as long as *any* window associated with the document is displaying a blocking window. It makes no sense to be blocked on the re-interpret dialog on one window, while freely typing in the other - allowing this in every otherwise blocking sheet situation opens the door for putting all sorts of things in weird states. Similarly, using the example from #98, if a "background sheet" is needed for a document that has *multiple* background tabs associated with it, they should *all* show the warning symbol, not just the first one. In this sense, with the current set-up, it is more preferable to be immediately asked to take action vs. being able to accidentally choose one of the other tabs, and edit as if it wasn't waiting on an answer on whether to revert or not. If you try this with the version available on he Mac App Store, you will enter a confusing state that where even though you answer the first sheet, the second also comes up, and you end up with a broken sheet that crashes:

<img width="796" alt="Screen Shot 2019-08-29 at 3 09 28 PM" src="https://user-images.githubusercontent.com/23753/63980219-cb26a980-ca6f-11e9-8e8b-798df0dff4e7.png">


As such, I am working on a separate fix that creates an alert queue for the document, such that they can all have a synchronized sheet state. This shouldn't be *tremendously* difficult, but is made harder by not being able to simply show sheets in the background: https://stackoverflow.com/questions/57433093/attach-sheet-without-ordering-front-or-making-key

