### PR TITLE
[FIX] Code won't unfold if textView has been scrolled

### DIFF
--- a/SubEthaEdit-Mac/Source/GutterRulerView.m
+++ b/SubEthaEdit-Mac/Source/GutterRulerView.m
@@ -362,8 +362,8 @@ FOUNDATION_STATIC_INLINE void DrawIndicatorForDepthInRect(int aDepth, NSRect aRe
         NSRange lineRange=[text lineRangeForRange:NSMakeRange(characterIndex,0)];
         NSRange attributeRange = NSMakeRange(lineRange.location,0);
 
-		// transform bounding rect to point coordinates
-		boundingRect = NSOffsetRect(boundingRect, 0, visibleRect.origin.y + textContainerInsetTopY);
+		// transform bounding rect to view coordinates
+		boundingRect = NSOffsetRect(boundingRect, 0, textContainerInsetTopY);
 		
 
 //		NSLog(@"%s bounds:%@ documentVisibleRect:%@",__FUNCTION__,NSStringFromRect([self bounds]),NSStringFromRect(visibleRect));


### PR DESCRIPTION
It seems like that a coordinate transformation has been done twice: one time at Line 365 and another time at Line 383.

I removed the translation in Line 365

Relates to #143