### PR TITLE
Set the ScriptMenu image as template image

### DIFF
--- a/SubEthaEdit-Mac/Source/AppController.m
+++ b/SubEthaEdit-Mac/Source/AppController.m
@@ -972,7 +972,9 @@ static AppController *sharedInstance = nil;
     int indexOfWindowMenu = [[NSApp mainMenu] indexOfItemWithTag:WindowMenuTag];
     if (indexOfWindowMenu != -1) {
         NSMenuItem *scriptMenuItem = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
-        [scriptMenuItem setImage:[NSImage imageNamed:@"ScriptMenu"]];
+        NSImage* scriptMenuIcon = [NSImage imageNamed:@"ScriptMenu"];
+        scriptMenuIcon.template = YES;
+        [scriptMenuItem setImage:scriptMenuIcon];
         [scriptMenuItem setTag:ScriptMenuTag];
         NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
         [scriptMenuItem setSubmenu:menu];


### PR DESCRIPTION
In macOS Catalina (Maybe also in earlier versions), the script menu item does not
show up in Dark Mode.

This marks the scriptMenuIcon as tempalte image to it's up to the OS how to display the image in the menu bar.

Before: 
<img width="602" alt="image" src="https://user-images.githubusercontent.com/178734/66528451-5adf5f00-ead6-11e9-94c3-e0010711f12b.png">

After:
<img width="638" alt="image" src="https://user-images.githubusercontent.com/178734/66528509-82362c00-ead6-11e9-8b5d-d9f174115895.png">

Tested on: macOS 10.15 (19A583)