### PR TITLE
[FIX #158] Remove code that sets the file URL based on the display name

### DIFF
--- a/SubEthaEdit-Mac/Source/PlainTextDocument.m
+++ b/SubEthaEdit-Mac/Source/PlainTextDocument.m
@@ -4561,14 +4561,9 @@ const void *SEESavePanelAssociationKey = &SEESavePanelAssociationKey;
     if (!I_flags.isSettingFileURL) {
         if (![self fileURL]) {
             [self setTemporaryDisplayName:aDisplayName];
-        } else {
-            [self setFileURL:[NSURL fileURLWithPath:[[self.fileURL.path stringByDeletingLastPathComponent] stringByAppendingPathComponent:aDisplayName]]];
         }
     }
-    if ([[super class] instancesRespondToSelector:_cmd]) { // _cmd is always the current selector
-//        NSLog(@"%s oh look, super supports us!",__FUNCTION__);
-        [super setDisplayName:aDisplayName];
-    }
+    [super setDisplayName:aDisplayName];
 	[self invalidateRestorableState];
 }
 


### PR DESCRIPTION
The code that causes this bug was introduced [a long time ago](https://github.com/subethaedit/SubEthaEdit/commit/3ddb95c63158b9b7dede30292f492282439ec348#diff-03c18423d53550a7154011845239384cL3472-L3473) to make the `make new document with properties {name: "something"}` Apple Script command available.

However I think, the `else { }` branch is not needed. Furthermore, I removed the check, whether `super` supports the `setDisplayName` selector as it always does so.