### PR TITLE
[FIX #164] Don't crash if multiple windows of the same document are being edited in block editing mode

### DIFF
--- a/SubEthaEdit-Mac/Source/PlainTextDocument.h
+++ b/SubEthaEdit-Mac/Source/PlainTextDocument.h
@@ -139,7 +139,7 @@ extern NSString * const PlainTextDocumentDidSaveShouldReloadWebPreviewNotificati
     
     NSMutableDictionary *I_printOptions;
 
-    TextOperation *I_currentTextOperation;
+    NSMutableArray <TCMMMOperation *> *I_currentTextOperations;
     
     NSDictionary *I_stateDictionaryFromLoading;
     

--- a/SubEthaEdit-Mac/Source/PlainTextEditor.h
+++ b/SubEthaEdit-Mac/Source/PlainTextEditor.h
@@ -78,6 +78,7 @@ extern NSString * const PlainTextEditorDidChangeSearchScopeNotification;
 - (void)updateViews;
 
 - (void)storePosition;
+- (void)restorePositionAfterOperations:(NSArray <TCMMMOperation *>*)operations;
 - (void)restorePositionAfterOperation:(TCMMMOperation *)aOperation;
 
 - (void)displayViewControllerInBottomArea:(NSViewController *)viewController;

--- a/SubEthaEdit-Mac/Source/PlainTextEditor.m
+++ b/SubEthaEdit-Mac/Source/PlainTextEditor.m
@@ -2105,11 +2105,15 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
     }
 }
 
-- (void)restorePositionAfterOperation:(TCMMMOperation *)aOperation {
+- (void)restorePositionAfterOperations:(NSArray <TCMMMOperation *>*)operations {
     if (I_storedPosition && [[I_textView string] length]) {
         NSLayoutManager *layoutManager = [I_textView layoutManager];
         TCMMMTransformator *transformator = [TCMMMTransformator sharedInstance];
-        [transformator transformOperation:I_storedPosition serverOperation:aOperation];
+        
+        for (TCMMMOperation *operation in operations) {
+            [transformator transformOperation:I_storedPosition serverOperation:operation];
+        }
+        
         unsigned glyphIndex = [layoutManager glyphRangeForCharacterRange:[I_storedPosition selectedRange] actualCharacterRange:NULL].location;
         NSRect boundingRect  = [layoutManager lineFragmentRectForGlyphAtIndex:glyphIndex
 															   effectiveRange:nil];
@@ -2123,6 +2127,11 @@ NSString * const PlainTextEditorDidChangeSearchScopeNotification = @"PlainTextEd
     }
 }
 
+- (void)restorePositionAfterOperation:(TCMMMOperation *)aOperation {
+    if (aOperation) {
+        [self restorePositionAfterOperations:@[aOperation]];
+    }
+}
 
 #pragma mark -
 #pragma mark ### display fixes for bottom status bar pop up buttons ###


### PR DESCRIPTION
This PR prevents multiple calls to `[editor storePosition]` and `[editor restorePositionAfterOperations:]` during block editing as these methods require the LayoutManager to perform layout which causes a crash if used between `[textStorage beginEditing]...[textStorage endEditing]`.

Instead, the restoration takes place, after `[textStorage endEditing]` has been called