### PR TITLE
Syntax highlighting breaks for lines that have 'def'

### DIFF
--- a/SubEthaEdit-Mac/Modes/Python.seemode/Contents/Resources/SyntaxDefinition.xml
+++ b/SubEthaEdit-Mac/Modes/Python.seemode/Contents/Resources/SyntaxDefinition.xml
@@ -346,7 +346,7 @@
 			</state>
 
 			<state id="Def Blocks" foldable="yes" scope="meta.block">
-				<begin><regex>^(?'defstartingwhitespace'[ \t]*)def[^:]+\:</regex></begin>
+				<begin><regex>^(?'defstartingwhitespace'[ \t]*)def[ \t]+[^:]+\:</regex></begin>
 				<end><regex>(?:\r?\n|\r)(?=(?:\r?\n|\r)(?:\r?\n|\r)(?#see-insert-start-group:defstartingwhitespace)\S|(?:\r?\n|\r)(?#see-insert-start-group:defstartingwhitespace)\S|(?#see-insert-start-group:defstartingwhitespace)\S|(?:\r?\n|\r)(?:\r?\n|\r)\S|(?:\r?\n|\r)\S|\S)</regex></end>
 				<import/>
 			</state>


### PR DESCRIPTION
Syntax highlighting breaks for lines that have 'def' in a variable name, like 'default'. Adding a check for a space after 'def' keyword in block regex