### PR TITLE
[FIX] Return a uniqueID as string

### DIFF
--- a/SubEthaEdit-Mac/Source/PlainTextDocument.m
+++ b/SubEthaEdit-Mac/Source/PlainTextDocument.m
@@ -6983,8 +6983,8 @@ static NSMutableArray<__kindof NSWindow *> *S_depthSortedWindows(NSArray<__kindo
     }
 }
 
-- (NSNumber *)uniqueID {
-    return [NSNumber numberWithInteger:self.hash];
+- (NSString *)uniqueID {
+    return @((NSInteger)self).stringValue;
 }
 
 - (id)objectSpecifier {

--- a/SubEthaEdit-Mac/SubEthaEdit.sdef
+++ b/SubEthaEdit-Mac/SubEthaEdit.sdef
@@ -390,7 +390,7 @@
 				<cocoa key="isDocumentEdited"/>
 			</property>
 
-			<property name="id" code="ID  " type="integer" access="r" description="The unique identifier of the document. Not persistant over launches.">
+			<property name="id" code="ID  " type="text" access="r" description="The unique identifier of the document. Not persistant over launches.">
 				<cocoa key="uniqueID"/>
 			</property>
 			<contents name="plain text" code="cTXT" type="plain text" description="The plain text object containing all the document's text.">


### PR DESCRIPTION
Fixes #215 
Also don't use the hash, as hashes are not necessarily different for distinct objects.